### PR TITLE
docs: add steam deck tracy build guide

### DIFF
--- a/README-STEAMDECK.md
+++ b/README-STEAMDECK.md
@@ -1,0 +1,37 @@
+# Building on Steam Deck with Tracy
+
+The Steam Deck runs a Linux-based system, so the project can be built
+natively. These steps enable the [Tracy profiler](https://github.com/wolfpld/tracy)
+for performance analysis.
+
+## Prerequisites
+
+Enable developer mode on the Deck and install build tools and libraries:
+
+```bash
+sudo pacman -S --needed base-devel cmake git sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net libpng libxml2 curl
+```
+
+## Building
+
+Run the helper script to configure and compile with Tracy support:
+
+```bash
+./tools/build_steamdeck_tracy.sh
+```
+
+The compiled client is located at
+`build-steamdeck-tracy/src/manaplus`.
+
+## Profiling with Tracy
+
+1. Download and run the Tracy capture server from the
+   [Tracy releases](https://github.com/wolfpld/tracy/releases) page
+   on your Deck or a separate PC.
+2. Start the client:
+   ```bash
+   ./build-steamdeck-tracy/src/manaplus
+   ```
+3. The client connects automatically to the Tracy server on `localhost`.
+   If the server runs on another machine, set the `TRACY_HOST`
+   environment variable to its address before launching the client.

--- a/tools/build_steamdeck_tracy.sh
+++ b/tools/build_steamdeck_tracy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build Mana Verse Client with Tracy profiling support on Steam Deck.
+# This script configures and compiles the project using SDL2 and Tracy.
+# Usage: ./tools/build_steamdeck_tracy.sh
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build-steamdeck-tracy"
+
+cmake -S "$ROOT_DIR" -B "$BUILD_DIR" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DENABLE_TRACY=ON \
+  -DUSE_SDL2=ON
+
+cmake --build "$BUILD_DIR" -j"$(nproc)"


### PR DESCRIPTION
## Summary
- document building the client with Tracy on Steam Deck
- add helper script for Tracy-enabled build

## Testing
- `bash -n tools/build_steamdeck_tracy.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b42b793348328a306f6c380289ef9