### PR TITLE
docs: add sdl2_gfx to steam deck setup

### DIFF
--- a/README-STEAMDECK.md
+++ b/README-STEAMDECK.md
@@ -9,7 +9,7 @@ for performance analysis.
 Enable developer mode on the Deck and install build tools and libraries:
 
 ```bash
-sudo pacman -S --needed base-devel cmake git sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net libpng libxml2 curl
+sudo pacman -S --needed base-devel cmake git sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx libpng libxml2 curl
 ```
 
 ## Building


### PR DESCRIPTION
## Summary
- include `sdl2_gfx` in Steam Deck install instructions so all SDL2-related dependencies are covered

## Testing
- `cmake ../..` *(fails: Could NOT find SDL)*

------
https://chatgpt.com/codex/tasks/task_e_689b46cabc988328b53a3ef6e8ab505e