### PR TITLE
docs: clarify SDL2 and curl dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -26,6 +26,19 @@ and some libraries. The required libraries are:
 * zlib 1.2.x        http://www.gzip.org/zlib/
 * libcurl           http://curl.haxx.se/libcurl/
 
+On most distributions the development packages for these libraries must be
+installed before building.  For example, on Debian or Ubuntu you can run:
+
+    sudo apt install build-essential cmake pkg-config \\
+        libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \\
+        libsdl2-net-dev libsdl2-ttf-dev libsdl2-gfx-dev \\
+        libcurl4-openssl-dev
+
+On Arch Linux and derivatives the equivalent command is:
+
+    sudo pacman -S base-devel cmake sdl2 sdl2_image \\
+        sdl2_mixer sdl2_net sdl2_ttf sdl2_gfx curl
+
 If you've cloned the Git repository, you will also need these tools to compile:
 
 * GNU automake 1.9  http://www.gnu.org/software/automake/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Azure CI: [![Build Status macosx](https://dev.azure.com/manaplus/ManaPlus/_apis/
  - [libpng](http://www.libpng.org/) (save screenshots)
  - [zlib](http://zlib.net/) (Archives)
 
+Make sure the development headers for these libraries are installed.  On
+Debian or Ubuntu the required packages can be installed with:
+
+    sudo apt install build-essential cmake pkg-config \\
+        libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \\
+        libsdl2-net-dev libsdl2-ttf-dev libsdl2-gfx-dev \\
+        libcurl4-openssl-dev
+
+For Arch Linux and derivatives use:
+
+    sudo pacman -S base-devel cmake sdl2 sdl2_image \\
+        sdl2_mixer sdl2_net sdl2_ttf sdl2_gfx curl
+
 #### Optional dependencies:
 
  - [gettext](https://www.gnu.org/software/gettext/) (translations)


### PR DESCRIPTION
## Summary
- document installing SDL2 libraries and libcurl development headers
- include example package installation commands for Debian/Ubuntu and Arch

## Testing
- `cmake /workspace/verse` *(fails: Could NOT find SDL)*


------
https://chatgpt.com/codex/tasks/task_e_689b4a0a3dfc8328ba75b3a03eac64f1