### PR TITLE
Fix command-line memory leak in SDLMain

### DIFF
--- a/src/SDLMain.m
+++ b/src/SDLMain.m
@@ -300,7 +300,17 @@ static void CustomApplicationMain (int argc, char **argv)
     /* Hand off to main application code */
     gCalledAppMainline = TRUE;
     status = SDL_main (gArgc, gArgv);
-    
+
+    /* Free duplicated command line arguments */
+    if (gArgv)
+    {
+        int i;
+        for (i = 0; i < gArgc; ++i)
+            SDL_free(gArgv[i]);
+        SDL_free(gArgv);
+        gArgv = NULL;
+    }
+
     /* We're done, thank you for playing */
     exit(status);
 }
@@ -358,9 +368,10 @@ int main (int argc, char **argv)
 {
     /* Copy the arguments into a global variable */
     /* This is passed if we are launched by double-clicking */
-    if ( argc >= 2 && strncmp (argv[1], "-psn", 4) == 0 ) {
-        gArgv = (char **) SDL_malloc(sizeof (char *) * 2);
-        gArgv[0] = argv[0];
+    if (argc >= 2 && strncmp(argv[1], "-psn", 4) == 0)
+    {
+        gArgv = (char **) SDL_malloc(sizeof(char *) * 2);
+        gArgv[0] = SDL_strdup(argv[0]);
         gArgv[1] = NULL;
         gArgc = 1;
         gFinderLaunch = YES;
@@ -369,9 +380,10 @@ int main (int argc, char **argv)
     {
         int i;
         gArgc = argc;
-        gArgv = (char **) SDL_malloc(sizeof (char *) * (argc+1));
-        for (i = 0; i <= argc; i++)
-            gArgv[i] = argv[i];
+        gArgv = (char **) SDL_malloc(sizeof(char *) * (argc + 1));
+        for (i = 0; i < argc; i++)
+            gArgv[i] = SDL_strdup(argv[i]);
+        gArgv[argc] = NULL;
         gFinderLaunch = NO;
     }
     


### PR DESCRIPTION
## Summary
- Duplicate and free command-line arguments on macOS to prevent leaks in SDLMain

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `./build.sh` *(fails: missing dependencies xsel, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b574bfca48328826e0a8b39e080cf