### PR TITLE
feat: install steam deck deps in tracy build script

### DIFF
--- a/README-STEAMDECK.md
+++ b/README-STEAMDECK.md
@@ -6,8 +6,16 @@ for performance analysis.
 
 ## Prerequisites
 
-Enable developer mode on the Deck and install build tools and libraries
-including Mesa for OpenGL headers:
+Enable developer mode on the Deck. The build script installs the following
+packages if they are missing:
+
+```
+base-devel cmake git \
+    sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx \
+    libpng zlib freetype2 harfbuzz libxml2 curl mesa
+```
+
+If you prefer to install them manually:
 
 ```bash
 sudo pacman -S --needed base-devel cmake git \
@@ -17,10 +25,11 @@ sudo pacman -S --needed base-devel cmake git \
 
 ## Building
 
-Run the helper script to configure and compile with Tracy support:
+Run the helper script to install dependencies, configure and compile with
+Tracy support. Use `sudo` if prompted for package installation:
 
 ```bash
-./tools/build_steamdeck_tracy.sh
+sudo ./tools/build_steamdeck_tracy.sh
 ```
 
 The compiled client is located at

--- a/tools/build_steamdeck_tracy.sh
+++ b/tools/build_steamdeck_tracy.sh
@@ -2,11 +2,32 @@
 set -euo pipefail
 
 # Build Mana Verse Client with Tracy profiling support on Steam Deck.
-# This script configures and compiles the project using SDL2 and Tracy.
+# This script installs required dependencies and then configures and
+# compiles the project using SDL2 and Tracy.
 # Usage: ./tools/build_steamdeck_tracy.sh
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="$ROOT_DIR/build-steamdeck-tracy"
+
+# Packages needed to build on Steam Deck
+PACKAGES=(
+  base-devel cmake git
+  sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx
+  libpng zlib freetype2 harfbuzz libxml2 curl mesa
+)
+
+# Install dependencies with pacman if available
+if command -v pacman >/dev/null 2>&1; then
+  if (( EUID != 0 )); then
+    SUDO=sudo
+  else
+    SUDO=""
+  fi
+  $SUDO pacman -S --needed --noconfirm "${PACKAGES[@]}"
+else
+  echo "Warning: pacman not found. Ensure the following packages are installed:" >&2
+  echo "  ${PACKAGES[*]}" >&2
+fi
 
 cmake -S "$ROOT_DIR" -B "$BUILD_DIR" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
## Summary
- automatically install Steam Deck build dependencies via pacman in the Tracy build helper
- document that the Steam Deck build script installs required packages and can be run with sudo

## Testing
- `./tools/build_steamdeck_tracy.sh >/tmp/buildlog.txt && tail -n 20 /tmp/buildlog.txt` *(fails: missing SDL2, OpenGL, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689b5a76ca048328a19ecc67404776b5