### PR TITLE
feat: install steam deck deps in tracy build script

### DIFF
--- a/README-STEAMDECK.md
+++ b/README-STEAMDECK.md
@@ -6,18 +6,36 @@ for performance analysis.
 
 ## Prerequisites
 
-Enable developer mode on the Deck and install build tools and libraries
-including Mesa for OpenGL headers:
+Enable developer mode on the Deck. The build script installs the following
+packages if they are missing:
+
+```
+base-devel cmake git \
+    sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx \
+    libpng zlib freetype2 harfbuzz libxml2 curl \ 
+    mesa libglvnd glu \ 
+    libjxl libjpeg-turbo libtiff libavif libwebp \ 
+    bzip2 brotli glib2 graphite libidn2 zstd krb5 openssl \
+    libpsl libssh2 libnghttp2 libnghttp3 xz icu
+```
+
+If you prefer to install them manually:
 
 ```bash
 sudo pacman -S --needed base-devel cmake git \
     sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx \
-    libpng zlib freetype2 harfbuzz libxml2 curl mesa
+    libpng zlib freetype2 harfbuzz libxml2 curl \ 
+    mesa libglvnd glu \ 
+    libjxl libjpeg-turbo libtiff libavif libwebp \ 
+    bzip2 brotli glib2 graphite libidn2 zstd krb5 openssl \
+    libpsl libssh2 libnghttp2 libnghttp3 xz icu
 ```
 
 ## Building
 
-Run the helper script to configure and compile with Tracy support:
+Run the helper script to install dependencies, configure and compile with
+Tracy support. Run it as your regular user; it will prompt for your password
+to install packages when required:
 
 ```bash
 ./tools/build_steamdeck_tracy.sh

--- a/tools/build_steamdeck_tracy.sh
+++ b/tools/build_steamdeck_tracy.sh
@@ -2,11 +2,40 @@
 set -euo pipefail
 
 # Build Mana Verse Client with Tracy profiling support on Steam Deck.
-# This script configures and compiles the project using SDL2 and Tracy.
+# This script installs required dependencies and then configures and
+# compiles the project using SDL2 and Tracy.
 # Usage: ./tools/build_steamdeck_tracy.sh
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="$ROOT_DIR/build-steamdeck-tracy"
+
+# Refuse to run as root so pkg-config can locate the Deck's libraries
+if (( EUID == 0 )); then
+  echo "Please run this script without sudo; it will use sudo when installing packages." >&2
+  exit 1
+fi
+
+# Packages needed to build on Steam Deck
+PACKAGES=(
+  base-devel cmake git
+  sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx
+  libpng zlib freetype2 harfbuzz libxml2 curl
+  mesa libglvnd glu
+  libjxl libjpeg-turbo libtiff libavif libwebp
+  bzip2 brotli glib2 graphite libidn2 zstd krb5 openssl
+  libpsl libssh2 libnghttp2 libnghttp3 xz icu
+)
+
+# Install dependencies with pacman if available
+if command -v pacman >/dev/null 2>&1; then
+  sudo pacman -S --needed --noconfirm "${PACKAGES[@]}"
+else
+  echo "Warning: pacman not found. Ensure the following packages are installed:" >&2
+  echo "  ${PACKAGES[*]}" >&2
+fi
+
+# Ensure pkg-config searches the system directories
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-/usr/lib/pkgconfig:/usr/share/pkgconfig}"
 
 cmake -S "$ROOT_DIR" -B "$BUILD_DIR" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
## Summary
- automatically install the full set of Steam Deck build dependencies in the Tracy helper script
- document the expanded dependency list and note that the script should be run without sudo; it will prompt for a password when installing packages
- refuse to run the helper script as root and set `PKG_CONFIG_PATH` so `pkg-config` locates Deck libraries

## Testing
- `./tools/build_steamdeck_tracy.sh > /tmp/buildlog.txt 2>&1`
- `tail -n 20 /tmp/buildlog.txt`


------
https://chatgpt.com/codex/tasks/task_e_689b5a76ca048328a19ecc67404776b5