### PR TITLE
Fix Steam Deck build script and avoid DEBUG macro collisions

### DIFF
--- a/README-STEAMDECK.md
+++ b/README-STEAMDECK.md
@@ -6,15 +6,23 @@ for performance analysis.
 
 ## Prerequisites
 
-Enable developer mode on the Deck. The build script installs the following
-packages if they are missing:
+Enable developer mode on the Deck. The root filesystem is read-only by
+default; enable writes with:
+
+```
+sudo steamos-readonly disable
+```
+
+The build script installs the following packages if they are missing:
 
 ```
 base-devel cmake git \
+    glibc linux-api-headers gcc \
     sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx \
-    libpng zlib freetype2 harfbuzz libxml2 curl \ 
-    mesa libglvnd glu \ 
-    libjxl libjpeg-turbo libtiff libavif libwebp \ 
+    libpng zlib freetype2 harfbuzz libxml2 curl \
+    mesa libglvnd glu \
+    libx11 xorgproto libxext libxrandr libxi libxrender libxtst \
+    libjxl libjpeg-turbo libtiff libavif libwebp \
     bzip2 brotli glib2 graphite libidn2 zstd krb5 openssl \
     libpsl libssh2 libnghttp2 libnghttp3 xz icu
 ```
@@ -23,10 +31,12 @@ If you prefer to install them manually:
 
 ```bash
 sudo pacman -S --needed base-devel cmake git \
+    glibc linux-api-headers gcc \
     sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx \
-    libpng zlib freetype2 harfbuzz libxml2 curl \ 
-    mesa libglvnd glu \ 
-    libjxl libjpeg-turbo libtiff libavif libwebp \ 
+    libpng zlib freetype2 harfbuzz libxml2 curl \
+    mesa libglvnd glu \
+    libx11 xorgproto libxext libxrandr libxi libxrender libxtst \
+    libjxl libjpeg-turbo libtiff libavif libwebp \
     bzip2 brotli glib2 graphite libidn2 zstd krb5 openssl \
     libpsl libssh2 libnghttp2 libnghttp3 xz icu
 ```
@@ -34,12 +44,11 @@ sudo pacman -S --needed base-devel cmake git \
 ## Building
 
 Run the helper script to install dependencies, configure and compile with
-Tracy support. Run it as your regular user; it will prompt for your password
-to install packages when required:
-
+Tracy support. Run it **without** `sudo`; the script elevates privileges
+only when installing packages:
 
 ```bash
-sudo ./tools/build_steamdeck_tracy.sh
+./tools/build_steamdeck_tracy.sh
 ```
 
 The compiled client is located at

--- a/src/enums/gui/chattabtype.h
+++ b/src/enums/gui/chattabtype.h
@@ -28,6 +28,10 @@
 #undef INPUT
 #endif  // INPUT
 
+#ifdef DEBUG
+#undef DEBUG
+#endif  // DEBUG
+
 PRAGMAMINGW(GCC diagnostic push)
 PRAGMAMINGW(GCC diagnostic ignored "-Wshadow")
 

--- a/tools/build_steamdeck_tracy.sh
+++ b/tools/build_steamdeck_tracy.sh
@@ -17,10 +17,12 @@ fi
 
 # Packages needed to build on Steam Deck
 PACKAGES=(
-  base-devel cm<<<<<<< obn4gu-codex/identify-and-fix-steam-deck-build-issuesake git
+  base-devel cmake git
+  glibc linux-api-headers gcc
   sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_net sdl2_gfx
-  libpng zlib freetype<<<<<<< obn4gu-codex/identify-and-fix-steam-deck-build-issues2 harfbuzz libxml2 curl
+  libpng zlib freetype2 harfbuzz libxml2 curl
   mesa libglvnd glu
+  libx11 xorgproto libxext libxrandr libxi libxrender libxtst
   libjxl libjpeg-turbo libtiff libavif libwebp
   bzip2 brotli glib2 graphite libidn2 zstd krb5 openssl
   libpsl libssh2 libnghttp2 libnghttp3 xz icu
@@ -36,9 +38,31 @@ fi
 
 # Ensure pkg-config searches the system directories
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-/usr/lib/pkgconfig:/usr/share/pkgconfig}"
+export CFLAGS="${CFLAGS:-} -UDEBUG"
+export CXXFLAGS="${CXXFLAGS:-} -UDEBUG"
+
+check_header() { echo "#include <$1>" | cc -E - >/dev/null 2>&1; }
+
+if ! check_header "sys/types.h"; then
+  echo "Missing standard headers. Install: sudo pacman -S glibc linux-api-headers gcc" >&2
+  exit 1
+fi
+
+if ! check_header "GL/gl.h"; then
+  echo "Missing OpenGL headers. Install: sudo pacman -S mesa libglvnd glu" >&2
+  exit 1
+fi
+
+if ! check_header "X11/Xlib.h"; then
+  echo "Missing X11 headers. Install: sudo pacman -S libx11 xorgproto libxext libxrandr libxi libxrender libxtst" >&2
+  exit 1
+fi
+
 cmake -S "$ROOT_DIR" -B "$BUILD_DIR" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DENABLE_TRACY=ON \
-  -DUSE_SDL2=ON
+  -DUSE_SDL2=ON \
+  -DCMAKE_C_FLAGS="$CFLAGS" \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS"
 
 cmake --build "$BUILD_DIR" -j"$(nproc)"


### PR DESCRIPTION
## Summary
- prevent DEBUG macro collisions in ChatTabType enum
- improve Steam Deck build script with dependency checks, X11/OpenGL packages, and -UDEBUG flags
- update Steam Deck README with new instructions and package list

## Testing
- `./tools/build_steamdeck_tracy.sh` *(fails: Please run this script without sudo; it will use sudo when installing packages.)*
- `su nobody -s /bin/bash -c './tools/build_steamdeck_tracy.sh'` *(fails: Warning: pacman not found. Ensure the following packages are installed: ... Missing OpenGL headers. Install: sudo pacman -S mesa libglvnd glu)*

------
https://chatgpt.com/codex/tasks/task_e_689b738765fc8328ac784256656672cf