### PR TITLE
Fix libxml2 legacy API linkage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2248,7 +2248,10 @@ ELSE()
 ENDIF(ENABLE_TMWA)
 
 ADD_EXECUTABLE(manaplus WIN32 ${SRCS} ${SRCS_EVOL})
-target_compile_definitions(manaplus PRIVATE LIBXML_LEGACY)
+find_package(LibXml2 REQUIRED)
+target_include_directories(manaplus PRIVATE ${LIBXML2_INCLUDE_DIR})
+target_link_libraries(manaplus PRIVATE LibXml2::LibXml2)
+target_compile_definitions(manaplus PRIVATE LIBXML_LEGACY=1)
 #ADD_EXECUTABLE(dyecmd WIN32 ${DYE_CMD_SRCS})
 
 IF (USE_SDL2)

--- a/src/utils/xml/libxml.cpp
+++ b/src/utils/xml/libxml.cpp
@@ -23,6 +23,13 @@
 
 #ifdef ENABLE_LIBXML
 
+#ifndef LIBXML_LEGACY
+#define LIBXML_LEGACY 1
+#endif
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+#include <libxml/xmlerror.h>
+
 #include "utils/xml/libxml.h"
 
 #include "fs/virtfs/fs.h"


### PR DESCRIPTION
## Summary
- Enable libxml2 legacy APIs and include parser/tree/error headers in libxml.cpp
- Link manaplus target against libxml2 and define LIBXML_LEGACY for compilation

## Testing
- `cmake -S . -B build` *(fails: Could NOT find SDL (missing: SDL_LIBRARY SDL_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_689b769d518c8328b2570c96486aa1d5